### PR TITLE
feat: Add Nebari Infrastructure Core (nic)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3828,6 +3828,9 @@ repository = "NathanBaulch/rainbow-roads"
 repository = "nats-io/natscli"
 
 [[packages]]
+repository = "nebari-dev/nebari-infrastructure-core"
+
+[[packages]]
 repository = "ned1313/terrahash"
 
 [[packages]]


### PR DESCRIPTION
Adds [Nebari Infrastructure Core](https://github.com/nebari-dev/nebari-infrastructure-core), an Apache-2.0 Go CLI (`nic`) that provisions Kubernetes clusters and bootstraps a platform stack on top of them.

I also ran the build locally to check compatibility
```
OK (generated recipe) (60 files, 1 packages):
  linux-64:      0.12.0-0, 0.11.0-0, ... 0.2.0-0
  linux-aarch64: 0.12.0-0, 0.11.0-0, ... 0.2.0-0
  osx-64:        0.12.0-0, 0.11.0-0, ... 0.2.0-0
  osx-arm64:     0.12.0-0, 0.11.0-0, ... 0.2.0-0
  win-64:        0.12.0-0, 0.11.0-0, ... 0.2.0-0
  win-arm64:     0.12.0-0, 0.11.0-0, ... 0.2.0-0
```