### PR TITLE
feat: add flip-link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2981,6 +2981,9 @@ repository = "knqyf263/sou"
 repository = "knqyf263/utern"
 
 [[packages]]
+repository = "knurling-rs/flip-link"
+
+[[packages]]
 repository = "ko-build/ko"
 
 [[packages]]


### PR DESCRIPTION
Add [flip-link](https://github.com/knurling-rs/flip-link), a linker wrapper that changes a program's memory layout by placing the stack below the `.bss` and `.data` sections.