### PR TITLE
Pin `yaml/yamlstar` to the CLI asset instead of the shared library

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6066,6 +6066,7 @@ repository = "yaml/yamlscript"
 
 [[packages]]
 repository = "yaml/yamlstar"
+release-prefix = "yamlstar"
 
 [[packages]]
 repository = "yannh/kubeconform"


### PR DESCRIPTION
## Problem

The published `yamlstar` package contains only the shared library, no CLI:

```console
$ pixi global install --channel https://prefix.dev/github-releases yamlstar
(installed) yamlstar 0.1.17
└── exposed       + libyamlstar.dylib, + libyamlstar.dylib.0, + libyamlstar.dylib.0.1.17
```

## Cause

Each release ships two archives per platform — `libyamlstar-0.1.19-macos-arm64.tar.xz`
and `yamlstar-0.1.19-macos-arm64.tar.xz`. Without a `release-prefix` the regex is
unanchored (`src/config_file.rs:79`), so both match, and `match_platform_names`
(`src/package_generation.rs:434`) returns the first asset in GitHub's order —
which is the `lib` one.

## Fix

`release-prefix = "yamlstar"` makes the regex `^yamlstar([\._-].+)?[\._-]{platform}`;
the `^` anchor excludes `libyamlstar-*`.

Verified by generating 0.1.18/0.1.19 recipes with a scratch config: all six
platforms (linux-64, linux-aarch64, osx-64, osx-arm64, win-64, win-arm64) now
resolve to `yamlstar-*`. `cargo test` and `cargo clippy -- -D warnings` clean.
