### PR TITLE
feat: add executable-name for bare binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,13 @@ be packaged.
 | ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `repository`     | yes      | GitHub repository in `owner/repo` format.                                                                                                                                                                                                                                                           |
 | `name`           | no       | Package name used in the Conda channel. Defaults to the repository name (the part after `/`).                                                                                                                                                                                                       |
+| `executable-name` | no       | Command name for bare binaries, including compressed binaries. Defaults to the package name. Does not affect archives. Omit `.exe`; Windows PE binaries get it automatically. |
 | `release-prefix` | no       | Expected prefix of release binary filenames. Defaults to the package name. Set to `""` to disable prefix matching.                                                                                                                                                                                  |
 | `tag-prefix`     | no       | Custom prefix to strip from release tags before version parsing. When set, only tags starting with this prefix are considered and the prefix is removed to extract the version.                                                                                                                     |
 | `platforms`      | no       | Override the default platform detection patterns. See [Platform Patterns](#platform-patterns) below.                                                                                                                                                                                                |
 | `expose`         | no       | List of extra top-level directory names to preserve in the conda package. By default only standard conda directories (`bin/`, `lib/`, `include/`, `share/`, `etc/`, `ssl/`) are kept; everything else is moved to `extras/`. Use for packages like JDKs that ship additional directories (e.g. `["conf", "jmods"]`). |
+
+>`executable-name`: must be nonempty and contain only ASCII letters, digits, `.`, `_`, or `-`; it cannot start with `-` or equal `.` or `..`. For repositories with a `[[packages.packages]]` list, set it on the individual sub-packages rather than the parent entry.
 
 ### Minimal Example
 
@@ -168,6 +171,12 @@ name = "oxlint"
 [[packages]]
 repository = "some-org/tool"
 platforms = { linux-64 = ["custom-linux-x64-regex"], win-64 = "null" }
+
+[[packages]]
+repository = "xataio/cli"
+name = "xata-cli"
+release-prefix = "xata"
+executable-name = "xata"
 ```
 
 ## Platform Patterns

--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ repository = "some-org/tool"
 platforms = { linux-64 = ["custom-linux-x64-regex"], win-64 = "null" }
 
 [[packages]]
-repository = "xataio/cli"
-name = "xata-cli"
-release-prefix = "xata"
-executable-name = "xata"
+repository = "owner/repo"
+name = "tool-cli"
+release-prefix = "tool"
+executable-name = "tool"
 ```
 
 ## Platform Patterns

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,8 @@ WORK_DIR="${PWD}"
 
 SRC="${PKG_NAME}-${PKG_VERSION}-${target_platform}"
 SRC_FILE="${WORK_DIR}/${SRC}"
+EXECUTABLE_NAME="${OCTOCONDA_EXECUTABLE_NAME:-${PKG_NAME}}"
+BARE_EXECUTABLE=""
 
 if ! test -f "$SRC_FILE"; then
     echo "${SRC} not found"
@@ -35,14 +37,17 @@ while [ "$STEP" -lt "$MAX_STEPS" ]; do
             ;;
         *PE32+* | *PE32*)
             mkdir -p "${PREFIX}/bin"
-            cp "$SRC_FILE" "${PREFIX}/bin/${PKG_NAME}.exe"
-            chmod 755 "${PREFIX}/bin/${PKG_NAME}.exe"
+            cp "$SRC_FILE" "${PREFIX}/bin/${EXECUTABLE_NAME}.exe"
+            chmod 755 "${PREFIX}/bin/${EXECUTABLE_NAME}.exe"
+            BARE_EXECUTABLE="${EXECUTABLE_NAME}.exe"
             break
             ;;
         *)
             # Bare binary or unknown — copy as executable
-            cp "$SRC_FILE" "${PREFIX}/${PKG_NAME}"
-            chmod 755 "${PREFIX}/${PKG_NAME}"
+            mkdir -p "${PREFIX}/bin"
+            cp "$SRC_FILE" "${PREFIX}/bin/${EXECUTABLE_NAME}"
+            chmod 755 "${PREFIX}/bin/${EXECUTABLE_NAME}"
+            BARE_EXECUTABLE="${EXECUTABLE_NAME}"
             break
             ;;
     esac
@@ -155,6 +160,10 @@ done
 cd "${PREFIX}/bin" || exit
 
 for f in *; do
+    # An explicit bare-binary name must not be shortened as a versioned filename.
+    if [ -n "${OCTOCONDA_EXECUTABLE_NAME:-}" ] && [ "$f" = "$BARE_EXECUTABLE" ]; then
+        continue
+    fi
     if [[ "$f" == *"-${PKG_VERSION}"* ]]; then
         short="${f%%-*}"
         mv "${f}" "${short}"

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -466,19 +466,19 @@ pub mod tests {
     #[test]
     fn test_executable_name_parses_without_changing_package_or_asset_names() {
         let entry: TomlPackage = toml::from_str(
-            r#"repository = "xataio/cli"
-name = "xata-cli"
-release-prefix = "xata"
-executable-name = "Xata_2.0-cli"
+            r#"repository = "owner/repo"
+name = "tool-cli"
+release-prefix = "tool"
+executable-name = "Tool_2.0-cli"
 "#,
         )
         .unwrap();
         let packages = expand_toml_package(entry).unwrap();
-        assert_eq!(packages[0].name, "xata-cli");
-        assert_eq!(packages[0].release_prefix.as_deref(), Some("xata"));
-        assert_eq!(packages[0].executable_name.as_deref(), Some("Xata_2.0-cli"));
+        assert_eq!(packages[0].name, "tool-cli");
+        assert_eq!(packages[0].release_prefix.as_deref(), Some("tool"));
+        assert_eq!(packages[0].executable_name.as_deref(), Some("Tool_2.0-cli"));
 
-        let entry = toml::from_str("repository = 'xataio/cli'\nname = 'xata-cli'").unwrap();
+        let entry = toml::from_str("repository = 'owner/repo'\nname = 'tool-cli'").unwrap();
         assert!(
             expand_toml_package(entry).unwrap()[0]
                 .executable_name
@@ -520,12 +520,12 @@ name = "first-cli"
             "",
             ".",
             "..",
-            "-xata",
-            "../xata",
-            "/xata",
-            r"bin\xata",
-            "xata\n",
-            "xata cli",
+            "-tool",
+            "../tool",
+            "/tool",
+            r"bin\tool",
+            "tool\n",
+            "tool cli",
         ] {
             // Exercise validation through both config expansion paths.
             for entry in [

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -30,6 +30,8 @@ pub enum StringOrList {
 #[derive(Deserialize)]
 pub struct TomlSubPackage {
     pub name: String,
+    #[serde(rename = "executable-name")]
+    pub executable_name: Option<String>,
     #[serde(rename = "release-prefix")]
     pub release_prefix: Option<String>,
     #[serde(rename = "tag-prefix")]
@@ -42,6 +44,8 @@ pub struct TomlSubPackage {
 #[derive(Deserialize)]
 pub struct TomlPackage {
     pub name: Option<String>,
+    #[serde(rename = "executable-name")]
+    pub executable_name: Option<String>,
     #[serde(rename = "release-prefix")]
     pub release_prefix: Option<String>,
     #[serde(rename = "tag-prefix")]
@@ -58,6 +62,7 @@ pub struct TomlPackage {
 #[derive(Clone, Debug)]
 pub struct Package {
     pub name: String,
+    pub executable_name: Option<String>,
     pub repository: Repository,
     release_prefix: Option<String>,
     pub tag_prefix: Option<String>,
@@ -223,9 +228,13 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
     let repository = Repository::try_from(value.repository.as_str())?;
 
     if let Some(sub_packages) = value.packages {
-        if value.name.is_some() || value.release_prefix.is_some() || value.tag_prefix.is_some() {
+        if value.name.is_some()
+            || value.executable_name.is_some()
+            || value.release_prefix.is_some()
+            || value.tag_prefix.is_some()
+        {
             anyhow::bail!(
-                "Repository \"{}\": top-level \"name\", \"release-prefix\", \
+                "Repository \"{}\": top-level \"name\", \"executable-name\", \"release-prefix\", \
                  and \"tag-prefix\" cannot be combined with a \"packages\" list",
                 value.repository,
             );
@@ -251,6 +260,7 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
                 let name = conda_package_name(Some(&sp.name), &repository.repo);
                 Ok(Package {
                     name,
+                    executable_name: validate_executable_name(sp.executable_name)?,
                     repository: repository.clone(),
                     release_prefix: sp.release_prefix,
                     tag_prefix: sp.tag_prefix,
@@ -263,6 +273,7 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
         let name = conda_package_name(value.name.as_deref(), &repository.repo);
         Ok(vec![Package {
             name,
+            executable_name: validate_executable_name(value.executable_name)?,
             repository,
             release_prefix: value.release_prefix,
             tag_prefix: value.tag_prefix,
@@ -270,6 +281,22 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
             expose: value.expose.unwrap_or_default(),
         }])
     }
+}
+
+fn validate_executable_name(name: Option<String>) -> anyhow::Result<Option<String>> {
+    if let Some(name) = &name {
+        anyhow::ensure!(
+            !name.is_empty()
+                && !name.starts_with('-')
+                && name != "."
+                && name != ".."
+                && name
+                    .bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || b"._-".contains(&c)),
+            "Invalid executable-name {name:?}: expected a filename containing only ASCII letters, digits, '.', '_' or '-' (not '.' or '..', and not starting with '-')",
+        );
+    }
+    Ok(name)
 }
 
 fn max_import_releases_default() -> usize {
@@ -417,6 +444,7 @@ pub mod tests {
             tag_prefix: None,
             repository: "foo/bar".to_string(),
             platforms: None,
+            executable_name: None,
             deprecated: false,
             packages: None,
             expose: None,
@@ -436,6 +464,84 @@ pub mod tests {
     }
 
     #[test]
+    fn test_executable_name_parses_without_changing_package_or_asset_names() {
+        let entry: TomlPackage = toml::from_str(
+            r#"repository = "xataio/cli"
+name = "xata-cli"
+release-prefix = "xata"
+executable-name = "Xata_2.0-cli"
+"#,
+        )
+        .unwrap();
+        let packages = expand_toml_package(entry).unwrap();
+        assert_eq!(packages[0].name, "xata-cli");
+        assert_eq!(packages[0].release_prefix.as_deref(), Some("xata"));
+        assert_eq!(packages[0].executable_name.as_deref(), Some("Xata_2.0-cli"));
+
+        let entry = toml::from_str("repository = 'xataio/cli'\nname = 'xata-cli'").unwrap();
+        assert!(
+            expand_toml_package(entry).unwrap()[0]
+                .executable_name
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_executable_name_on_sub_packages() {
+        let entry = toml::from_str(
+            r#"repository = "owner/repo"
+[[packages]]
+name = "first-cli"
+executable-name = "first"
+[[packages]]
+name = "second-cli"
+"#,
+        )
+        .unwrap();
+        let packages = expand_toml_package(entry).unwrap();
+        assert_eq!(packages[0].executable_name.as_deref(), Some("first"));
+        assert!(packages[1].executable_name.is_none());
+
+        let entry = toml::from_str(
+            r#"repository = "owner/repo"
+executable-name = "ambiguous"
+[[packages]]
+name = "first-cli"
+"#,
+        )
+        .unwrap();
+        let err = expand_toml_package(entry).unwrap_err();
+        assert!(err.to_string().contains("cannot be combined"), "{err}");
+    }
+
+    #[test]
+    fn test_invalid_executable_names_rejected() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "-xata",
+            "../xata",
+            "/xata",
+            r"bin\xata",
+            "xata\n",
+            "xata cli",
+        ] {
+            // Exercise validation through both config expansion paths.
+            for entry in [
+                format!("repository = 'owner/repo'\nexecutable-name = {name:?}"),
+                format!(
+                    "repository = 'owner/repo'\n[[packages]]\nname = 'cli'\nexecutable-name = {name:?}"
+                ),
+            ] {
+                let entry = toml::from_str(&entry).unwrap();
+                let err = expand_toml_package(entry).unwrap_err();
+                assert!(err.to_string().contains("Invalid executable-name"), "{err}");
+            }
+        }
+    }
+
+    #[test]
     fn test_duplicate_package_names_rejected() {
         let config = toml_config(vec![
             TomlPackage {
@@ -444,6 +550,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -454,6 +561,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "bob/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -475,6 +583,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/something".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -485,6 +594,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "bob/other".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -506,6 +616,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -516,6 +627,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "bob/bar".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -537,6 +649,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -547,6 +660,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "bob/bar".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -564,6 +678,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: true,
                 packages: None,
                 expose: None,
@@ -574,6 +689,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "bob/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -593,6 +709,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: true,
                 packages: None,
                 expose: None,
@@ -603,6 +720,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "bob/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: true,
                 packages: None,
                 expose: None,
@@ -620,6 +738,7 @@ pub mod tests {
             tag_prefix: None,
             repository: "oxc-project/oxc".to_string(),
             platforms: None,
+            executable_name: None,
             deprecated: false,
             packages: Some(vec![
                 TomlSubPackage {
@@ -627,6 +746,7 @@ pub mod tests {
                     release_prefix: Some("oxfmt".to_string()),
                     tag_prefix: None,
                     platforms: None,
+                    executable_name: None,
                     expose: None,
                 },
                 TomlSubPackage {
@@ -634,6 +754,7 @@ pub mod tests {
                     release_prefix: Some("oxlint".to_string()),
                     tag_prefix: None,
                     platforms: None,
+                    executable_name: None,
                     expose: None,
                 },
             ]),
@@ -656,12 +777,14 @@ pub mod tests {
             tag_prefix: None,
             repository: "owner/repo".to_string(),
             platforms: None,
+            executable_name: None,
             deprecated: false,
             packages: Some(vec![TomlSubPackage {
                 name: "pkg".to_string(),
                 release_prefix: None,
                 tag_prefix: None,
                 platforms: None,
+                executable_name: None,
                 expose: None,
             }]),
 
@@ -683,6 +806,7 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "alice/foo".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: None,
                 expose: None,
@@ -693,12 +817,14 @@ pub mod tests {
                 tag_prefix: None,
                 repository: "oxc-project/oxc".to_string(),
                 platforms: None,
+                executable_name: None,
                 deprecated: false,
                 packages: Some(vec![TomlSubPackage {
                     name: "foo".to_string(),
                     release_prefix: None,
                     tag_prefix: None,
                     platforms: None,
+                    executable_name: None,
                     expose: None,
                 }]),
 
@@ -720,6 +846,7 @@ pub mod tests {
             tag_prefix: None,
             repository: "graalvm/graalvm-ce-builds".to_string(),
             platforms: None,
+            executable_name: None,
             deprecated: false,
             packages: None,
             expose: Some(vec!["conf".to_string(), "jmods".to_string()]),
@@ -740,6 +867,7 @@ pub mod tests {
             tag_prefix: None,
             repository: "owner/repo".to_string(),
             platforms: None,
+            executable_name: None,
             deprecated: false,
             packages: None,
             expose: Some(vec!["conf".to_string()]),

--- a/src/package_generation.rs
+++ b/src/package_generation.rs
@@ -804,13 +804,13 @@ mod tests {
     #[test]
     fn test_recipe_executable_name_and_expose() {
         let repository = serde_json::from_value(serde_json::json!({
-            "id": 1, "name": "cli", "url": "https://example.invalid/"
+            "id": 1, "name": "repo", "url": "https://example.invalid/"
         }))
         .unwrap();
         let asset = serde_json::from_value(serde_json::json!({
             "url": "https://example.invalid/asset",
-            "browser_download_url": "https://example.invalid/xata-linux-x64",
-            "id": 1, "node_id": "n", "name": "xata-linux-x64",
+            "browser_download_url": "https://example.invalid/tool-linux-x64",
+            "id": 1, "node_id": "n", "name": "tool-linux-x64",
             "state": "uploaded", "content_type": "application/octet-stream",
             "size": 1, "download_count": 0,
             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"
@@ -818,14 +818,14 @@ mod tests {
         .unwrap();
 
         let config: crate::config_file::TomlConfig = toml::from_str(
-            "[conda]\nchannel = 'test'\n[[packages]]\nrepository = 'xataio/cli'\nname = 'xata-cli'",
+            "[conda]\nchannel = 'test'\n[[packages]]\nrepository = 'owner/repo'\nname = 'tool-cli'",
         )
         .unwrap();
         let mut package = crate::config_file::Config::try_from(config)
             .unwrap()
             .packages
             .remove(0);
-        for executable_name in [None, Some("xata")] {
+        for executable_name in [None, Some("tool")] {
             for expose in [false, true] {
                 package.executable_name = executable_name.map(str::to_owned);
                 package.expose = if expose {
@@ -846,13 +846,13 @@ mod tests {
                 )
                 .unwrap();
                 let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
-                assert!(recipe.contains("  name: xata-cli\n"), "{recipe}");
+                assert!(recipe.contains("  name: tool-cli\n"), "{recipe}");
                 assert!(
-                    recipe.contains("  file_name: \"xata-cli-1.0.0-linux-64\""),
+                    recipe.contains("  file_name: \"tool-cli-1.0.0-linux-64\""),
                     "{recipe}"
                 );
                 assert_eq!(
-                    recipe.contains("      OCTOCONDA_EXECUTABLE_NAME: \"xata\""),
+                    recipe.contains("      OCTOCONDA_EXECUTABLE_NAME: \"tool\""),
                     executable_name.is_some(),
                     "{recipe}"
                 );
@@ -878,19 +878,19 @@ mod tests {
         use std::process::Command;
 
         let binary = b"#!/bin/sh\nexit 0\n";
-        for name in [None, Some("xata"), Some("xata-1.0.0"), Some("bin")] {
+        for name in [None, Some("tool"), Some("tool-1.0.0"), Some("bin")] {
             let work_dir = tempfile::tempdir().unwrap();
             let prefix = work_dir.path().join("prefix");
             std::fs::create_dir(&prefix).unwrap();
             generate_build_script(work_dir.path()).unwrap();
-            std::fs::write(work_dir.path().join("xata-cli-1.0.0-linux-64"), binary).unwrap();
+            std::fs::write(work_dir.path().join("tool-cli-1.0.0-linux-64"), binary).unwrap();
 
             let mut command = Command::new("bash");
             command
                 .arg("build.sh")
                 .current_dir(work_dir.path())
                 .env("PREFIX", &prefix)
-                .env("PKG_NAME", "xata-cli")
+                .env("PKG_NAME", "tool-cli")
                 .env("PKG_VERSION", "1.0.0")
                 .env("target_platform", "linux-64")
                 .env_remove("OCTOCONDA_EXECUTABLE_NAME")
@@ -906,7 +906,7 @@ mod tests {
             );
 
             let bin = prefix.join("bin");
-            let executable = bin.join(name.unwrap_or("xata-cli"));
+            let executable = bin.join(name.unwrap_or("tool-cli"));
             assert_eq!(std::fs::read(&executable).unwrap(), binary);
             assert_eq!(
                 std::fs::metadata(executable).unwrap().permissions().mode() & 0o777,

--- a/src/package_generation.rs
+++ b/src/package_generation.rs
@@ -707,7 +707,14 @@ fn generate_rattler_build_recipe(
     let package_version = yaml_escape(package_version);
     let archive = yaml_escape(&archive);
 
-    let build_extra_section = if !package.expose.is_empty() {
+    let mut script_env = Vec::new();
+    if let Some(name) = &package.executable_name {
+        script_env.push(format!(
+            "      OCTOCONDA_EXECUTABLE_NAME: \"{}\"",
+            yaml_escape(name)
+        ));
+    }
+    let mut build_extra_section = if !package.expose.is_empty() {
         let standard_dirs = ["bin", "etc", "extras", "include", "lib", "share", "ssl"];
         let mut file_globs: Vec<String> = standard_dirs
             .iter()
@@ -719,12 +726,15 @@ fn generate_rattler_build_recipe(
         let files_section = format!("  files:\n    include:\n{}", file_globs.join("\n"));
 
         let expose_val = package.expose.join("|");
-        let env_section = format!("  script:\n    env:\n      OCTOCONDA_EXPOSE: \"{expose_val}\"");
+        script_env.push(format!("      OCTOCONDA_EXPOSE: \"{expose_val}\""));
 
-        format!("{files_section}\n{env_section}")
+        files_section
     } else {
         String::new()
     };
+    if !script_env.is_empty() {
+        build_extra_section.push_str(&format!("\n  script:\n    env:\n{}", script_env.join("\n")));
+    }
 
     let content = format!(
         r#"package:
@@ -790,6 +800,121 @@ mod tests {
     use super::*;
 
     use crate::config_file::tests::get_patterns_for;
+
+    #[test]
+    fn test_recipe_executable_name_and_expose() {
+        let repository = serde_json::from_value(serde_json::json!({
+            "id": 1, "name": "cli", "url": "https://example.invalid/"
+        }))
+        .unwrap();
+        let asset = serde_json::from_value(serde_json::json!({
+            "url": "https://example.invalid/asset",
+            "browser_download_url": "https://example.invalid/xata-linux-x64",
+            "id": 1, "node_id": "n", "name": "xata-linux-x64",
+            "state": "uploaded", "content_type": "application/octet-stream",
+            "size": 1, "download_count": 0,
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"
+        }))
+        .unwrap();
+
+        let config: crate::config_file::TomlConfig = toml::from_str(
+            "[conda]\nchannel = 'test'\n[[packages]]\nrepository = 'xataio/cli'\nname = 'xata-cli'",
+        )
+        .unwrap();
+        let mut package = crate::config_file::Config::try_from(config)
+            .unwrap()
+            .packages
+            .remove(0);
+        for executable_name in [None, Some("xata")] {
+            for expose in [false, true] {
+                package.executable_name = executable_name.map(str::to_owned);
+                package.expose = if expose {
+                    vec!["conf".to_owned()]
+                } else {
+                    vec![]
+                };
+                let work_dir = tempfile::tempdir().unwrap();
+                generate_build_script(work_dir.path()).unwrap();
+                let recipe_dir = generate_rattler_build_recipe(
+                    work_dir.path(),
+                    &package,
+                    "1.0.0",
+                    0,
+                    &Platform::Linux64,
+                    &repository,
+                    &asset,
+                )
+                .unwrap();
+                let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
+                assert!(recipe.contains("  name: xata-cli\n"), "{recipe}");
+                assert!(
+                    recipe.contains("  file_name: \"xata-cli-1.0.0-linux-64\""),
+                    "{recipe}"
+                );
+                assert_eq!(
+                    recipe.contains("      OCTOCONDA_EXECUTABLE_NAME: \"xata\""),
+                    executable_name.is_some(),
+                    "{recipe}"
+                );
+                assert_eq!(
+                    recipe.contains("      OCTOCONDA_EXPOSE: \"conf\""),
+                    expose,
+                    "{recipe}"
+                );
+                assert_eq!(recipe.contains("      - conf/**"), expose, "{recipe}");
+                assert_eq!(
+                    recipe.matches("  script:\n").count(),
+                    usize::from(executable_name.is_some() || expose),
+                    "{recipe}"
+                );
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_build_script_bare_executable_names() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Command;
+
+        let binary = b"#!/bin/sh\nexit 0\n";
+        for name in [None, Some("xata"), Some("xata-1.0.0"), Some("bin")] {
+            let work_dir = tempfile::tempdir().unwrap();
+            let prefix = work_dir.path().join("prefix");
+            std::fs::create_dir(&prefix).unwrap();
+            generate_build_script(work_dir.path()).unwrap();
+            std::fs::write(work_dir.path().join("xata-cli-1.0.0-linux-64"), binary).unwrap();
+
+            let mut command = Command::new("bash");
+            command
+                .arg("build.sh")
+                .current_dir(work_dir.path())
+                .env("PREFIX", &prefix)
+                .env("PKG_NAME", "xata-cli")
+                .env("PKG_VERSION", "1.0.0")
+                .env("target_platform", "linux-64")
+                .env_remove("OCTOCONDA_EXECUTABLE_NAME")
+                .env_remove("OCTOCONDA_EXPOSE");
+            if let Some(name) = name {
+                command.env("OCTOCONDA_EXECUTABLE_NAME", name);
+            }
+            let output = command.output().expect("run build.sh with Bash");
+            assert!(
+                output.status.success(),
+                "executable-name {name:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            let bin = prefix.join("bin");
+            let executable = bin.join(name.unwrap_or("xata-cli"));
+            assert_eq!(std::fs::read(&executable).unwrap(), binary);
+            assert_eq!(
+                std::fs::metadata(executable).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+            assert_eq!(std::fs::read_dir(bin).unwrap().count(), 1);
+        }
+    }
 
     fn zoxide_names() -> Vec<&'static str> {
         vec![


### PR DESCRIPTION
Following on https://github.com/hunger/octoconda/issues/81 and as discussed this adds ability to define an executable name different from the package name for bare binaries sources.

Full disclosure, as a non rust dev, gpt astra was heavily used for this PR even though a general guidance and integration was human supervised.