### PR TITLE
feat: add Liquibase with configurable recipe overrides

### DIFF
--- a/.github/workflows/octoconda.yaml
+++ b/.github/workflows/octoconda.yaml
@@ -136,6 +136,9 @@ jobs:
       - name: Install 7zip-standalone
         run: sudo apt-get install -y 7zip-standalone && which 7zz
 
+      - name: Test package integrity verifier
+        run: python3 scripts/verify_package.py --self-test
+
       - name: Install rattler-build (binary)
         run: |
           mkdir bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "memo-map"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5449c8c750f1a07ea702bbd212bd999fceece9b3d1508b17023b3e174583124b"
+
+[[package]]
+name = "minijinja"
+version = "2.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86886cf6dbf4e614b19c9a1eec9775f021869d7eadde0fc73921a81b90c9b4c9"
+dependencies = [
+ "aho-corasick",
+ "memo-map",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2348,7 @@ dependencies = [
  "clap",
  "futures",
  "glob",
+ "minijinja",
  "octocrab",
  "rand 0.10.2",
  "rattler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.51", features = ["derive"] }
+minijinja = { version = "2.24.0", features = ["custom_syntax", "json"] }
 octocrab = { version = "0.54.0", features = ["stream"] }
 
 rattler = "0.41.0"

--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ verbatim, not templated, and receive rattler-build's usual environment variables
 Only trusted configuration and scripts should be used. See
 [recipes/liquibase.yaml.j2](recipes/liquibase.yaml.j2) for a complete example.
 
+## Package Integrity
+
+Local `build-one` runs and CI publishing verify the completed Conda archives
+before declaring success or uploading. Every payload file and bundled license
+must have the same SHA-256 as a file in one of the selected upstream release
+assets. Renames and internal symlinks are allowed; modified or added bytes fail
+verification. Generated Conda metadata under `info/` is excluded, except for
+`info/licenses/`. Broken links and links outside the package are rejected.
+
+Generated launcher scripts may be declared in a recipe's
+`extra.generated-launchers` mapping, from exact package-relative path to SHA-256.
+These are explicit, byte-pinned exceptions, not filename patterns: a missing or
+modified launcher fails verification too.
+
+The generator records upstream URLs and available checksums separately in
+`upstream-assets.json`, so custom recipes do not choose their own verification
+sources. The verifier downloads and hashes these assets before running the build,
+checks upstream checksums when supplied, and publishes only the verified archives.
+This host-side check also covers cross-built packages without executing them.
+It requires Python 3.12+, `file`, `7zz`, and `rattler-build`, available in the
+project's Pixi environment and CI runners.
+
+Run the regression tests with `pixi run test-package-integrity`. To check an
+existing archive against local downloads, use
+`pixi run python scripts/verify_package.py verify PACKAGE.conda --source ASSET`;
+repeat `--source` for additional upstream assets.
+
 ## Platform Patterns
 
 Octoconda ships with built-in regex patterns that match common binary naming

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ be packaged.
 | `release-prefix` | no       | Expected prefix of release binary filenames. Defaults to the package name. Set to `""` to disable prefix matching.                                                                                                                                                                                  |
 | `tag-prefix`     | no       | Custom prefix to strip from release tags before version parsing. When set, only tags starting with this prefix are considered and the prefix is removed to extract the version.                                                                                                                     |
 | `platforms`      | no       | Override the default platform detection patterns. See [Platform Patterns](#platform-patterns) below.                                                                                                                                                                                                |
+| `recipe-template` | no      | Path to a custom recipe template, relative to the configuration file. Replaces the generated recipe. See [Recipe Overrides](#recipe-overrides). |
+| `build-script`   | no       | Path to a custom Bash build script, relative to the configuration file. Copied into each recipe directory as `build.sh`. |
 | `expose`         | no       | List of extra top-level directory names to preserve in the conda package. By default only standard conda directories (`bin/`, `lib/`, `include/`, `share/`, `etc/`, `ssl/`) are kept; everything else is moved to `extras/`. Use for packages like JDKs that ship additional directories (e.g. `["conf", "jmods"]`). |
 
 ### Minimal Example
@@ -114,6 +116,42 @@ name = "oxlint"
 repository = "some-org/tool"
 platforms = { linux-64 = ["custom-linux-x64-regex"], win-64 = "null" }
 ```
+
+## Recipe Overrides
+
+`recipe-template` and `build-script` are independent, optional settings. Omitting
+either preserves its default behavior. For entries with a `[[packages.packages]]`
+list, set overrides on individual sub-packages, not the parent repository.
+Paths may also be absolute; missing files and directories are rejected when
+loading configuration. Override files are read at runtime, so distribute them
+alongside your configuration, not just the Octoconda binary. No CI changes are
+needed here because the publishing jobs check out the repository.
+
+Templates use [MiniJinja](https://docs.rs/minijinja/latest/minijinja/) with
+`[[ expression ]]` for values, `[% if condition %] ... [% endif %]` for blocks,
+and `[# comment #]` for comments. Use `| tojson` when inserting string values:
+it produces quoted, escaped strings valid in YAML. Unknown variables are errors.
+Native rattler-build `${{ ... }}` expressions are left unchanged.
+
+The following values are available to every template:
+
+| Value | Meaning |
+| ----- | ------- |
+| `name`, `version`, `build_number` | Conda package identity and build number. |
+| `version_major` | First dot-separated component of `version`, as a string. |
+| `target_platform` | Target Conda platform, such as `linux-64`. |
+| `source_url`, `source_file_name` | Selected release asset URL and the generated download filename. |
+| `source_sha256` | GitHub-provided SHA-256, or `none` if unavailable. |
+| `upstream_repository` | Configured `owner/repo`. |
+| `homepage`, `repository_url`, `license` | GitHub repository metadata, or `none` if unavailable. License IDs are normalized as for default recipes. |
+| `summary` | Trimmed GitHub description, or an empty string. |
+| `build_extra` | Preformatted YAML for the existing `expose` setting; insert directly under `build` without quoting. |
+
+A template replaces the entire recipe: it owns source checksums, dependencies,
+license declarations, tests, and provenance fields. Build scripts are copied
+verbatim, not templated, and receive rattler-build's usual environment variables.
+Only trusted configuration and scripts should be used. See
+[recipes/liquibase.yaml.j2](recipes/liquibase.yaml.j2) for a complete example.
 
 ## Platform Patterns
 

--- a/config.toml
+++ b/config.toml
@@ -3340,6 +3340,13 @@ repository = "lintnet/lintnet"
 repository = "linuxkit/linuxkit"
 
 [[packages]]
+repository = "liquibase/liquibase"
+release-prefix = "liquibase"
+recipe-template = "recipes/liquibase.yaml.j2"
+build-script = "scripts/build_liquibase.sh"
+platforms = { linux-32 = "null", linux-64 = ['\d+\.\d+\.\d+\.tar\.gz$'], linux-aarch64 = ['\d+\.\d+\.\d+\.tar\.gz$'], osx-64 = ['\d+\.\d+\.\d+\.tar\.gz$'], osx-arm64 = ['\d+\.\d+\.\d+\.tar\.gz$'], win-32 = "null", win-64 = ['\d+\.\d+\.\d+\.tar\.gz$'], win-arm64 = "null" }
+
+[[packages]]
 repository = "liquidmetal-dev/flintlock"
 
 [[packages]]

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [tasks]
 add-repo = { cmd = "python scripts/add_repo.py" }
 test-add-repo = { cmd = "python scripts/add_repo.py --self-test" }
+test-package-integrity = { cmd = "python scripts/verify_package.py --self-test" }
 mastodon-repos = { cmd = "python scripts/mastodon_repos.py" }
 rebalance-repos = { cmd = "python scripts/rebalance_repos.py" }
 build-one = { cmd = "bash scripts/build_one.sh" }

--- a/recipes/liquibase.yaml.j2
+++ b/recipes/liquibase.yaml.j2
@@ -38,6 +38,10 @@ tests:
         - liquibase --version
 
 extra:
+[% if target_platform == "win-64" %]
+  generated-launchers:
+    Scripts/liquibase.bat: "4bfdfdd2fe9847d1bf1d2b71ab843ce8396e92ec33850c226e86752ab7c648e2"
+[% endif %]
   upstream-forge: github.com
 [% if source_sha256 %]
   upstream-sha256: [[ source_sha256 | tojson ]]

--- a/recipes/liquibase.yaml.j2
+++ b/recipes/liquibase.yaml.j2
@@ -1,0 +1,63 @@
+package:
+  name: [[ name | tojson ]]
+  version: [[ version | tojson ]]
+
+source:
+  url: [[ source_url | tojson ]]
+[% if source_sha256 %]
+  sha256: [[ source_sha256 | tojson ]]
+[% endif %]
+  file_name: [[ source_file_name | tojson ]]
+
+build:
+  number: [[ build_number ]]
+  dynamic_linking:
+    binary_relocation: false
+  prefix_detection:
+    ignore: true
+[[ build_extra ]]
+
+requirements:
+  build:
+    - 7zip
+  run:
+    - openjdk >=17
+
+tests:
+  - package_contents:
+      files:
+        not_exists:
+          - .*
+          - share/liquibase/internal/**/liquibase-commercial*.jar
+          - share/liquibase/internal/**/liquibase-checks.jar
+      bin:
+        - "*"
+  - if: build_platform == target_platform
+    then:
+      script:
+        - liquibase --version
+
+extra:
+  upstream-forge: github.com
+[% if source_sha256 %]
+  upstream-sha256: [[ source_sha256 | tojson ]]
+[% endif %]
+  upstream-version: [[ version | tojson ]]
+  upstream-repository: [[ upstream_repository | tojson ]]
+  release-download-url: [[ source_url | tojson ]]
+
+about:
+  description: [[ summary | tojson ]]
+  summary: [[ summary | tojson ]]
+[% if homepage %]
+  homepage: [[ homepage | tojson ]]
+[% endif %]
+[% if repository_url %]
+  repository: [[ repository_url | tojson ]]
+[% endif %]
+[% if version_major | int >= 5 %]
+  license: "FSL-1.1-ALv2"
+[% else %]
+  license: "Apache-2.0"
+[% endif %]
+  license_file: LICENSE.txt

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -106,12 +106,11 @@ for f in *; do
                 mv "${f}" bin
                 ;;
             *.[1-9]|*.[1-9][a-z])
-                # Man page — compress and move to share/man/manN/
+                # Man page — move unchanged to share/man/manN/
                 section="${f##*.}"
                 section="${section%[a-z]}"
                 mkdir -p "share/man/man${section}"
-                gzip -c "${f}" > "share/man/man${section}/${f}.gz"
-                rm "${f}"
+                mv "${f}" "share/man/man${section}/"
                 ;;
             *.[1-9].gz|*.[1-9][a-z].gz)
                 # Already-compressed man page — move to share/man/manN/

--- a/scripts/build_liquibase.sh
+++ b/scripts/build_liquibase.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+TARGET_PLATFORM="${target_platform:?}"
+SOURCE="${PKG_NAME}-${PKG_VERSION}-${TARGET_PLATFORM}"
+DESTINATION="${PREFIX}/share/liquibase"
+
+mkdir -p "${DESTINATION}"
+7zz x -so "${SOURCE}" > liquibase.tar
+7zz x -y -snld "-o${DESTINATION}" liquibase.tar
+test -f "${DESTINATION}/internal/lib/liquibase-core.jar"
+find "${DESTINATION}/internal" -type f \
+    \( -name 'liquibase-commercial*.jar' -o -name 'liquibase-checks.jar' \) -delete
+cp "${DESTINATION}/LICENSE.txt" "${SRC_DIR}/LICENSE.txt"
+
+case "${TARGET_PLATFORM}" in
+    win-*)
+        mkdir -p "${PREFIX}/Scripts"
+        printf '@echo off\r\ncall "%%~dp0..\\share\\liquibase\\liquibase.bat" %%*\r\nexit /b %%ERRORLEVEL%%\r\n' \
+            > "${PREFIX}/Scripts/liquibase.bat"
+        ;;
+    *)
+        chmod 755 "${DESTINATION}/liquibase"
+        mkdir -p "${PREFIX}/bin"
+        ln -s ../share/liquibase/liquibase "${PREFIX}/bin/liquibase"
+        ;;
+esac

--- a/scripts/build_one.sh
+++ b/scripts/build_one.sh
@@ -3,6 +3,7 @@ set -e
 
 REPO="${1:?Usage: build_one.sh <owner/repo>}"
 OUTPUT_DIR="test-output"
+VERIFIER="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/verify_package.py"
 
 # Wipe any artefacts from a previous run so the generator's File::create_new
 # calls for build.sh / env.sh don't fail, and stale recipes from other repos
@@ -34,7 +35,7 @@ for recipe in "${RECIPES[@]}"; do
   platform=$(basename "$PLATFORM_DIR")
 
   echo "******* ${package} [${platform}] *******"
-  if (cd "${PACKAGE_DIR}" && rattler-build build --recipe recipe.yaml --target-platform="${platform}" --output-dir="${OUTPUT_DIR}/packages"); then
+  if python3 "${VERIFIER}" build "${recipe}" --target-platform="${platform}" --output-dir="${OUTPUT_DIR}/packages/${platform}/${package}"; then
     SUCCESS=$((SUCCESS + 1))
   else
     FAILED=$((FAILED + 1))
@@ -43,3 +44,4 @@ done
 
 echo
 echo "Done: ${SUCCESS} succeeded, ${FAILED} failed (${RECIPE_COUNT} total)"
+test "${FAILED}" -eq 0

--- a/scripts/package_and_upload_all.sh
+++ b/scripts/package_and_upload_all.sh
@@ -8,6 +8,7 @@ test -f "./env.sh" && source "./env.sh"
 test -f "build.sh" || exit 1
 
 CURRENT="${PWD}"
+VERIFIER="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/verify_package.py"
 
 echo "Build and upload all conda recipes in ${CURRENT}"
 
@@ -30,11 +31,10 @@ for recipe in "${RECIPES[@]}"; do
   platform=$(basename "$PLATFORM_DIR")
 
   echo "******* ${package} [${platform}] (${count}/${RECIPE_COUNT}, ${FAILED_PACKAGES} not OK) ******"
-  BUILD_OUTPUT=$(cd "${PACKAGE_DIR}" \
-      && rattler-build publish \
-          --to "https://prefix.dev/${TARGET_CHANNEL}" \
-          --generate-attestation \
-          --target-platform="${platform}" 2>&1) \
+    BUILD_OUTPUT=$(python3 "${VERIFIER}" build "${recipe}" \
+      --target-platform="${platform}" \
+      --output-dir="${PACKAGE_DIR}/output" \
+      --publish-to="https://prefix.dev/${TARGET_CHANNEL}" 2>&1) \
     && SUCCESS_PACKAGES=$((SUCCESS_PACKAGES + 1)) \
     || { FAILED_PACKAGES=$((FAILED_PACKAGES + 1)); echo "${BUILD_OUTPUT}"; }
   count=$((count + 1))

--- a/scripts/verify_package.py
+++ b/scripts/verify_package.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Verify that packaged file bytes come from upstream release assets."""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+from urllib.request import urlopen
+
+
+def file_sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file's contents."""
+    with path.open("rb") as stream:
+        return hashlib.file_digest(stream, "sha256").hexdigest()
+
+
+def tree_hashes(root: Path, *, package: bool = False) -> dict[str, str]:
+    """Hash files, rejecting links that escape the extracted tree."""
+    root = root.resolve()
+    hashes: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root)
+        if package and relative.parts[0] == "info" and relative.parts[1:2] != ("licenses",):
+            continue
+        resolved = path.resolve(strict=True)
+        if not resolved.is_relative_to(root):
+            raise ValueError(f"Link escapes extracted tree: {relative}")
+        if path.is_file():
+            hashes[relative.as_posix()] = file_sha256(path)
+        elif not path.is_dir():
+            raise ValueError(f"Unsupported file type: {relative}")
+    return hashes
+
+
+def verify_contents(
+    package_dir: Path, upstream_hashes: set[str], launchers: dict[str, str] | None = None,
+) -> int:
+    """Require every payload and license file to match an upstream SHA-256."""
+    launchers = launchers or {}
+    packaged_hashes = tree_hashes(package_dir, package=True)
+    if not packaged_hashes:
+        raise ValueError("Package contains no payload files")
+    for name, digest in launchers.items():
+        if name not in packaged_hashes or packaged_hashes[name] != digest:
+            raise ValueError(f"Generated launcher is missing or has a different SHA-256: {name}")
+    unmatched = [
+        f"{name}: SHA-256 {digest}"
+        for name, digest in packaged_hashes.items()
+        if digest not in upstream_hashes and name not in launchers
+    ]
+    if unmatched:
+        raise ValueError("Files not found in upstream assets:\n" + "\n".join(unmatched))
+    return len(packaged_hashes)
+
+
+def unpack_source(source: Path, destination: Path) -> None:
+    """Extract release archives without modifying the downloaded file."""
+    destination.mkdir()
+    with tempfile.TemporaryDirectory() as temporary:
+        current = source.resolve()
+        for step in range(5):
+            file_type = subprocess.check_output(["file", "--brief", str(current)], text=True).lower()
+            if any(kind in file_type for kind in ("zip archive", "tar archive", "7-zip archive")):
+                subprocess.run(
+                    ["7zz", "x", "-y", "-snld", f"-o{destination.resolve()}", str(current)],
+                    check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                )
+                return
+            if any(kind in file_type for kind in (
+                "gzip compressed", "xz compressed", "zstandard compressed", "zstd compressed",
+                "bzip2 compressed",
+            )):
+                decompressed = Path(temporary) / str(step)
+                with decompressed.open("wb") as stream:
+                    subprocess.run(
+                        ["7zz", "e", "-so", "-snld", str(current)], check=True,
+                        stdout=stream, stderr=subprocess.PIPE,
+                    )
+                current = decompressed
+            else:
+                shutil.copyfile(current, destination / source.name)
+                return
+    raise ValueError(f"Too many compression layers: {source}")
+
+
+def source_hashes(sources: list[Path], directory: Path) -> set[str]:
+    """Collect SHA-256 digests from every supplied upstream distribution."""
+    hashes: set[str] = set()
+    for index, source in enumerate(sources):
+        extracted = directory / f"source-{index}"
+        hashes.add(file_sha256(source))
+        unpack_source(source, extracted)
+        hashes.update(tree_hashes(extracted).values())
+    if not hashes:
+        raise ValueError("Upstream assets contain no files")
+    return hashes
+
+
+def download_sources(manifest: Path, directory: Path) -> list[Path]:
+    """Download generator-selected assets and check available upstream digests."""
+    assets = json.loads(manifest.read_text())
+    if not isinstance(assets, list) or not assets:
+        raise ValueError(f"No upstream assets in {manifest}")
+    sources: list[Path] = []
+    for index, asset in enumerate(assets):
+        url = asset["url"]
+        if not isinstance(url, str) or not url.startswith("https://"):
+            raise ValueError("Upstream asset URLs must use HTTPS")
+        source = directory / f"download-{index}"
+        with urlopen(url, timeout=60) as response, source.open("wb") as stream:
+            shutil.copyfileobj(response, stream)
+        expected = asset.get("sha256")
+        if expected is not None and file_sha256(source) != expected:
+            raise ValueError(f"Upstream SHA-256 mismatch: {url}")
+        sources.append(source)
+    return sources
+
+
+def verify_archive(package: Path, upstream_hashes: set[str]) -> None:
+    """Verify the actual Conda payload after all build-time processing."""
+    with tempfile.TemporaryDirectory() as temporary:
+        extracted = Path(temporary) / "package"
+        subprocess.run(
+            ["rattler-build", "package", "extract", str(package), "--dest", str(extracted)],
+            check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        about = json.loads((extracted / "info" / "about.json").read_text())
+        launchers = about.get("extra", {}).get("generated-launchers", {})
+        count = verify_contents(extracted, upstream_hashes, launchers)
+        print(
+            f"Verified {count} file SHA-256 digests ({len(launchers)} approved launchers): "
+            f"{package.name}", flush=True,
+        )
+
+
+def built_packages(output: Path, platform: str) -> list[Path]:
+    """Find target and noarch outputs, excluding source caches and broken builds."""
+    return sorted(
+        package
+        for subdir in {platform, "noarch"}
+        for pattern in ("*.conda", "*.tar.bz2")
+        for package in (output / subdir).glob(pattern)
+    )
+
+
+def build_verified(recipe: Path, platform: str, output: Path, publish_to: str | None) -> None:
+    """Build and verify all outputs before optionally publishing those archives."""
+    recipe = recipe.resolve()
+    output = output.resolve()
+    if built_packages(output, platform):
+        raise ValueError(f"Output directory already contains packages: {output}")
+    with tempfile.TemporaryDirectory() as temporary:
+        directory = Path(temporary)
+        sources = download_sources(recipe.parent / "upstream-assets.json", directory)
+        hashes = source_hashes(sources, directory)
+    subprocess.run(
+        ["rattler-build", "build", "--recipe", str(recipe), "--target-platform", platform,
+         "--output-dir", str(output)], check=True,
+    )
+    packages = built_packages(output, platform)
+    if not packages:
+        raise ValueError("Build produced no packages to verify")
+    for package in packages:
+        verify_archive(package, hashes)
+    if publish_to:
+        subprocess.run(
+            ["rattler-build", "publish", "--to", publish_to, "--generate-attestation",
+             *map(str, packages)], check=True,
+        )
+
+
+def main() -> None:
+    """Run standalone verification or the verified build/publish workflow."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    verify = commands.add_parser("verify", help="Verify a built package against release assets")
+    verify.add_argument("package", type=Path)
+    upstream = verify.add_mutually_exclusive_group(required=True)
+    upstream.add_argument("--source", type=Path, action="append", help="Local upstream asset; repeatable")
+    upstream.add_argument("--sources-json", type=Path, help="Generator's upstream-assets.json")
+    build = commands.add_parser("build", help="Build, verify, and optionally publish")
+    build.add_argument("recipe", type=Path)
+    build.add_argument("--target-platform", required=True)
+    build.add_argument("--output-dir", type=Path, required=True)
+    build.add_argument("--publish-to")
+    arguments = parser.parse_args()
+    try:
+        if arguments.command == "build":
+            build_verified(arguments.recipe, arguments.target_platform, arguments.output_dir,
+                           arguments.publish_to)
+        else:
+            with tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary)
+                sources = arguments.source or download_sources(arguments.sources_json, directory)
+                verify_archive(arguments.package, source_hashes(sources, directory))
+    except (ValueError, OSError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f"Package verification failed: {error}\n")
+
+
+class VerificationTests(unittest.TestCase):
+    """Exercise byte identity independently of file layout."""
+
+    def test_renamed_files_links_and_multiple_sources(self) -> None:
+        """Accept identical bytes from either source, including linked launchers."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sources = [root / "source-one", root / "source-two"]
+            for source in sources:
+                source.mkdir()
+            (sources[0] / "original").write_bytes(b"upstream executable")
+            (sources[1] / "LICENSE").write_bytes(b"upstream license")
+            package = root / "package"
+            (package / "bin").mkdir(parents=True)
+            (package / "bin" / "renamed").write_bytes(b"upstream executable")
+            (package / "bin" / "alias").symlink_to("renamed")
+            (package / "info" / "licenses").mkdir(parents=True)
+            (package / "info" / "index.json").write_text("{}")
+            (package / "info" / "licenses" / "LICENSE").write_bytes(b"upstream license")
+            hashes = {digest for source in sources for digest in tree_hashes(source).values()}
+            self.assertEqual(verify_contents(package, hashes), 3)
+            (package / "info" / "licenses" / "LICENSE").write_bytes(b"modified license")
+            with self.assertRaisesRegex(ValueError, "info/licenses/LICENSE"):
+                verify_contents(package, hashes)
+
+    def test_modified_and_added_files_fail(self) -> None:
+        """Reject changed files, generated wrappers, and hidden payload files."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source"
+            source.mkdir()
+            (source / "original").write_bytes(b"upstream executable")
+            package = root / "package"
+            package.mkdir()
+            for name in ["original", "wrapper.bat", ".hidden"]:
+                with self.subTest(name=name):
+                    path = package / name
+                    path.write_bytes(b"different bytes")
+                    with self.assertRaisesRegex(ValueError, name):
+                        verify_contents(package, set(tree_hashes(source).values()))
+                    path.unlink()
+
+    def test_external_and_broken_links_fail(self) -> None:
+        """Reject links whose contents cannot be verified inside the package."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            package = root / "package"
+            package.mkdir()
+            (root / "external").write_bytes(b"outside package")
+            link = package / "link"
+            link.symlink_to("../external")
+            with self.assertRaisesRegex(ValueError, "escapes"):
+                tree_hashes(package, package=True)
+            link.unlink()
+            link.symlink_to("missing")
+            with self.assertRaises(FileNotFoundError):
+                tree_hashes(package, package=True)
+
+    def test_archive_and_bare_binary(self) -> None:
+        """Hash both archived contents and standalone downloaded executables."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive = root / "archive-without-extension"
+            with zipfile.ZipFile(archive, "w") as zipped:
+                zipped.writestr("nested/file", b"archived bytes")
+            binary = root / "binary"
+            binary.write_bytes(b"standalone bytes")
+            hashes = source_hashes([archive, binary], root)
+            self.assertEqual(hashes, {
+                hashlib.sha256(b"archived bytes").hexdigest(), file_sha256(binary),
+                file_sha256(archive),
+            })
+
+    def test_launcher_exception_requires_exact_path_and_bytes(self) -> None:
+        """Allow only an explicitly declared launcher with unchanged bytes."""
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary)
+            (package / "Scripts").mkdir()
+            launcher = package / "Scripts" / "tool.bat"
+            launcher.write_bytes(b"@echo off\r\n")
+            approved = {"Scripts/tool.bat": file_sha256(launcher)}
+            self.assertEqual(verify_contents(package, set(), approved), 1)
+            launcher.rename(package / "Scripts" / "other.bat")
+            with self.assertRaisesRegex(ValueError, "launcher"):
+                verify_contents(package, set(), approved)
+            launcher.write_bytes(b"modified launcher")
+            with self.assertRaisesRegex(ValueError, "launcher"):
+                verify_contents(package, set(), approved)
+
+    def test_generic_script_preserves_manpage(self) -> None:
+        """Keep relocated executables and manual pages byte-identical."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            prefix = root / "prefix"
+            prefix.mkdir()
+            archive = root / "tool-1.0-linux-64"
+            with tarfile.open(archive, "w:gz") as packed:
+                for name, content, mode in [
+                    ("tool", b"#!/bin/sh\nexit 0\n", 0o755),
+                    ("tool.1", b".TH TOOL 1\n", 0o644),
+                ]:
+                    member = tarfile.TarInfo(name)
+                    member.size = len(content)
+                    member.mode = mode
+                    packed.addfile(member, io.BytesIO(content))
+            hashes = source_hashes([archive], root)
+            subprocess.run(
+                ["bash", str(Path(__file__).resolve().with_name("build.sh"))], cwd=root,
+                env={**os.environ, "PKG_NAME": "tool", "PKG_VERSION": "1.0",
+                     "target_platform": "linux-64", "PREFIX": str(prefix)},
+                check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+            self.assertTrue((prefix / "share" / "man" / "man1" / "tool.1").is_file())
+            self.assertEqual(verify_contents(prefix, hashes), 2)
+
+    def test_upstream_checksum_mismatch_fails(self) -> None:
+        """Reject an upstream download that does not match GitHub's digest."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = root / "upstream-assets.json"
+            manifest.write_text(json.dumps([{
+                "url": "https://example.com/tool.zip", "sha256": "0" * 64,
+            }]))
+            with (
+                patch(__name__ + ".urlopen", return_value=io.BytesIO(b"wrong download")),
+                self.assertRaisesRegex(ValueError, "Upstream SHA-256 mismatch"),
+            ):
+                download_sources(manifest, root)
+
+    def test_verification_failure_prevents_publish(self) -> None:
+        """Never invoke publishing after a package fails the integrity test."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+
+            def fake_build(command: list[str], *, check: bool) -> None:
+                self.assertEqual(command[1], "build")
+                self.assertTrue(check)
+                (output / "linux-64").mkdir(parents=True)
+                (output / "linux-64" / "tool.conda").touch()
+                (output / "linux-64" / "tool-second.conda").touch()
+
+            with (
+                patch(__name__ + ".download_sources", return_value=[]),
+                patch(__name__ + ".source_hashes", return_value={"upstream"}),
+                patch(__name__ + ".verify_archive", side_effect=[None, ValueError("changed bytes")]),
+                patch("subprocess.run", side_effect=fake_build) as run,
+            ):
+                with self.assertRaisesRegex(ValueError, "changed bytes"):
+                    build_verified(root / "recipe.yaml", "linux-64", output, "https://example.com")
+                self.assertEqual(run.call_count, 1)
+
+    def test_publish_uses_verified_archive_without_rebuilding(self) -> None:
+        """Publish exactly the archive that passed verification, with attestations."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+            package = output / "linux-64" / "tool.conda"
+            verified: list[Path] = []
+
+            def fake_run(command: list[str], *, check: bool) -> None:
+                self.assertTrue(check)
+                if command[1] == "build":
+                    package.parent.mkdir(parents=True)
+                    package.touch()
+                    (output / "src_cache").mkdir()
+                    (output / "src_cache" / "download.tar.bz2").touch()
+                else:
+                    self.assertEqual(verified, [package])
+                    self.assertEqual(command, [
+                        "rattler-build", "publish", "--to", "https://example.com",
+                        "--generate-attestation", str(package),
+                    ])
+
+            with (
+                patch(__name__ + ".download_sources", return_value=[]),
+                patch(__name__ + ".source_hashes", return_value={"upstream"}),
+                patch(__name__ + ".verify_archive", side_effect=lambda package, hashes: verified.append(package)),
+                patch("subprocess.run", side_effect=fake_run) as run,
+            ):
+                build_verified(root / "recipe.yaml", "linux-64", output, "https://example.com")
+                self.assertEqual(run.call_count, 2)
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] == ["--self-test"]:
+        unittest.main(argv=[sys.argv[0]])
+    else:
+        main()

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use anyhow::{Context, anyhow};
@@ -37,6 +37,8 @@ pub struct TomlSubPackage {
     pub platforms: Option<HashMap<Platform, StringOrList>>,
     #[serde(default)]
     pub expose: Option<Vec<String>>,
+    #[serde(flatten)]
+    pub recipe: RecipeOverrides,
 }
 
 #[derive(Deserialize)]
@@ -53,6 +55,15 @@ pub struct TomlPackage {
     pub packages: Option<Vec<TomlSubPackage>>,
     #[serde(default)]
     pub expose: Option<Vec<String>>,
+    #[serde(flatten)]
+    pub recipe: RecipeOverrides,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RecipeOverrides {
+    pub recipe_template: Option<PathBuf>,
+    pub build_script: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -63,6 +74,7 @@ pub struct Package {
     pub tag_prefix: Option<String>,
     platform_pattern: HashMap<Platform, Vec<String>>,
     pub expose: Vec<String>,
+    pub recipe: RecipeOverrides,
 }
 
 impl Package {
@@ -243,6 +255,13 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
             );
         }
 
+        if value.recipe.recipe_template.is_some() || value.recipe.build_script.is_some() {
+            anyhow::bail!(
+                "Repository \"{}\": set recipe-template and build-script on individual sub-packages",
+                value.repository,
+            );
+        }
+
         sub_packages
             .into_iter()
             .map(|sp| {
@@ -254,6 +273,7 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
                     tag_prefix: sp.tag_prefix,
                     platform_pattern: resolve_platforms(sp.platforms),
                     expose: sp.expose.unwrap_or_default(),
+                    recipe: sp.recipe,
                 })
             })
             .collect()
@@ -266,6 +286,7 @@ fn expand_toml_package(value: TomlPackage) -> anyhow::Result<Vec<Package>> {
             tag_prefix: value.tag_prefix,
             platform_pattern: resolve_platforms(value.platforms),
             expose: value.expose.unwrap_or_default(),
+            recipe: value.recipe,
         }])
     }
 }
@@ -395,12 +416,103 @@ pub fn parse_config(path: &Path) -> anyhow::Result<Config> {
         path.display()
     ))?;
 
-    config.try_into()
+    let mut config: Config = config.try_into()?;
+    let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    for package in &mut config.packages {
+        for (setting, override_path) in [
+            ("recipe-template", &mut package.recipe.recipe_template),
+            ("build-script", &mut package.recipe.build_script),
+        ] {
+            if let Some(override_path) = override_path {
+                let resolved = config_dir.join(&*override_path);
+                *override_path = resolved.canonicalize().with_context(|| {
+                    format!(
+                        "Package \"{}\": failed to resolve {setting} {}",
+                        package.name,
+                        resolved.display(),
+                    )
+                })?;
+                if !override_path.is_file() {
+                    anyhow::bail!(
+                        "Package \"{}\": {setting} {} is not a file",
+                        package.name,
+                        override_path.display(),
+                    );
+                }
+            }
+        }
+    }
+    Ok(config)
 }
 
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
+    #[test]
+    fn test_recipe_overrides() {
+        let directory = tempfile::tempdir().unwrap();
+        let template_path = directory.path().join("custom.yaml");
+        let script_path = directory.path().join("custom.sh");
+        std::fs::write(&template_path, "package: {}").unwrap();
+        std::fs::write(&script_path, "exit 0").unwrap();
+        let config_path = directory.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"[conda]
+channel = "test-channel"
+[[packages]]
+repository = "example/standalone"
+recipe-template = "custom.yaml"
+build-script = "custom.sh"
+[[packages]]
+repository = "example/multiple"
+[[packages.packages]]
+name = "custom"
+recipe-template = "custom.yaml"
+[[packages.packages]]
+name = "ordinary"
+"#,
+        )
+        .unwrap();
+        let config = parse_config(&config_path).unwrap();
+        assert_eq!(
+            config.packages[0].recipe.recipe_template,
+            Some(template_path.clone())
+        );
+        assert_eq!(config.packages[0].recipe.build_script, Some(script_path));
+        assert_eq!(
+            config.packages[1].recipe.recipe_template,
+            Some(template_path)
+        );
+        assert!(config.packages[1].recipe.build_script.is_none());
+        assert!(config.packages[2].recipe.recipe_template.is_none());
+        std::fs::remove_file(directory.path().join("custom.yaml")).unwrap();
+        let error = parse_config(&config_path).unwrap_err().to_string();
+        assert!(error.contains("standalone"));
+        assert!(error.contains("recipe-template"));
+    }
+
+    #[test]
+    fn test_recipe_overrides_rejected_on_repository_group() {
+        let config: TomlConfig = toml::from_str(
+            r#"[conda]
+channel = "test-channel"
+[[packages]]
+repository = "example/multiple"
+build-script = "custom.sh"
+[[packages.packages]]
+name = "custom"
+"#,
+        )
+        .unwrap();
+        assert!(
+            Config::try_from(config)
+                .unwrap_err()
+                .to_string()
+                .contains("individual sub-packages")
+        );
+    }
 
     pub fn get_patterns_for(release_prefix: &str) -> HashMap<Platform, Vec<regex::Regex>> {
         let rp = if release_prefix.is_empty() {
@@ -418,6 +530,7 @@ pub mod tests {
             deprecated: false,
             packages: None,
             expose: None,
+            recipe: RecipeOverrides::default(),
         };
         let mut packages = expand_toml_package(toml).unwrap();
         packages.remove(0).platform_pattern().unwrap()
@@ -445,6 +558,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: None,
@@ -455,6 +569,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -476,6 +591,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: Some("foo".to_string()),
@@ -486,6 +602,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -507,6 +624,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: Some("foo".to_string()),
@@ -517,6 +635,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -538,6 +657,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: None,
@@ -548,6 +668,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         Config::try_from(config).unwrap();
@@ -565,6 +686,7 @@ pub mod tests {
                 deprecated: true,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: None,
@@ -575,6 +697,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         let cfg = Config::try_from(config).unwrap();
@@ -594,6 +717,7 @@ pub mod tests {
                 deprecated: true,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: None,
@@ -604,6 +728,7 @@ pub mod tests {
                 deprecated: true,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         let cfg = Config::try_from(config).unwrap();
@@ -626,6 +751,7 @@ pub mod tests {
                     tag_prefix: None,
                     platforms: None,
                     expose: None,
+                    recipe: RecipeOverrides::default(),
                 },
                 TomlSubPackage {
                     name: "oxlint".to_string(),
@@ -633,10 +759,12 @@ pub mod tests {
                     tag_prefix: None,
                     platforms: None,
                     expose: None,
+                    recipe: RecipeOverrides::default(),
                 },
             ]),
 
             expose: None,
+            recipe: RecipeOverrides::default(),
         }]);
         let cfg = Config::try_from(config).unwrap();
         assert_eq!(cfg.packages.len(), 2);
@@ -661,9 +789,11 @@ pub mod tests {
                 tag_prefix: None,
                 platforms: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             }]),
 
             expose: None,
+            recipe: RecipeOverrides::default(),
         }]);
         let err = Config::try_from(config).unwrap_err();
         assert!(
@@ -684,6 +814,7 @@ pub mod tests {
                 deprecated: false,
                 packages: None,
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
             TomlPackage {
                 name: None,
@@ -698,9 +829,11 @@ pub mod tests {
                     tag_prefix: None,
                     platforms: None,
                     expose: None,
+                    recipe: RecipeOverrides::default(),
                 }]),
 
                 expose: None,
+                recipe: RecipeOverrides::default(),
             },
         ]);
         let err = Config::try_from(config).unwrap_err();
@@ -721,6 +854,7 @@ pub mod tests {
             deprecated: false,
             packages: None,
             expose: Some(vec!["conf".to_string(), "jmods".to_string()]),
+            recipe: RecipeOverrides::default(),
         }]);
         let cfg = Config::try_from(config).unwrap();
         assert_eq!(cfg.packages.len(), 1);
@@ -741,6 +875,7 @@ pub mod tests {
             deprecated: false,
             packages: None,
             expose: Some(vec!["conf".to_string()]),
+            recipe: RecipeOverrides::default(),
         }]);
         let cfg = Config::try_from(config).unwrap();
         assert_eq!(cfg.packages[0].expose, vec!["conf".to_string()]);

--- a/src/package_generation.rs
+++ b/src/package_generation.rs
@@ -667,6 +667,26 @@ about:
     )
 }
 
+fn render_recipe_template(path: &Path, context: minijinja::Value) -> anyhow::Result<String> {
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read recipe template {}", path.display()))?;
+    let mut environment = minijinja::Environment::new();
+    environment.set_syntax(
+        minijinja::syntax::SyntaxConfig::builder()
+            .variable_delimiters("[[", "]]")
+            .block_delimiters("[%", "%]")
+            .comment_delimiters("[#", "#]")
+            .build()?,
+    );
+    environment.set_undefined_behavior(minijinja::UndefinedBehavior::Strict);
+    environment.set_trim_blocks(true);
+    environment.set_lstrip_blocks(true);
+    environment.set_keep_trailing_newline(true);
+    environment
+        .render_str(&source, context)
+        .with_context(|| format!("Failed to render recipe template {}", path.display()))
+}
+
 fn generate_rattler_build_recipe(
     work_dir: &Path,
     package: &Package,
@@ -681,16 +701,14 @@ fn generate_rattler_build_recipe(
     let recipe_dir = platform_dir.join(format!("{package_name}-{package_version}-{build_number}",));
     std::fs::create_dir_all(&recipe_dir).context("Failed to create recipe directory")?;
 
-    let build_script_source = work_dir.join("build.sh");
+    let build_script_source = package
+        .recipe
+        .build_script
+        .clone()
+        .unwrap_or_else(|| work_dir.join("build.sh"));
     let build_script_destination = recipe_dir.join("build.sh");
     std::fs::copy(&build_script_source, &build_script_destination).context(format!(
         "Failed to copy build script from {build_script_source:?} to {build_script_destination:?}"
-    ))?;
-
-    let recipe_file = recipe_dir.join("recipe.yaml");
-    let mut file = std::fs::File::create_new(&recipe_file).context(format!(
-        "Failed to create recipe file \"{}\"",
-        recipe_file.display()
     ))?;
 
     let url = asset.browser_download_url.to_string();
@@ -702,10 +720,6 @@ fn generate_rattler_build_recipe(
     let pn = package_name;
 
     let archive = format!("{pn}-{package_version}-{target_platform}");
-
-    let url = yaml_escape(&url);
-    let package_version = yaml_escape(package_version);
-    let archive = yaml_escape(&archive);
 
     let build_extra_section = if !package.expose.is_empty() {
         let standard_dirs = ["bin", "etc", "extras", "include", "lib", "share", "ssl"];
@@ -726,8 +740,32 @@ fn generate_rattler_build_recipe(
         String::new()
     };
 
-    let content = format!(
-        r#"package:
+    let content = if let Some(template) = &package.recipe.recipe_template {
+        render_recipe_template(
+            template,
+            minijinja::context! {
+                name => package_name,
+                version => package_version,
+                version_major => package_version.split('.').next().unwrap_or(package_version),
+                build_number => build_number,
+                target_platform => target_platform.to_string(),
+                source_url => url,
+                source_sha256 => extract_digest(asset).map(|(_, value)| value),
+                source_file_name => archive,
+                upstream_repository => package.repository.to_string(),
+                homepage => repository.homepage.as_deref(),
+                repository_url => repository.html_url.as_ref().map(|url| url.as_str()),
+                summary => repository.description.as_deref().unwrap_or_default().trim(),
+                license => repository.license.as_ref().map(|license| fix_spdx_license(&license.spdx_id)),
+                build_extra => build_extra_section,
+            },
+        )?
+    } else {
+        let url = yaml_escape(&url);
+        let package_version = yaml_escape(package_version);
+        let archive = yaml_escape(&archive);
+        format!(
+            r#"package:
   name: {pn}
   version: "{package_version}"
 
@@ -752,8 +790,14 @@ tests:
         - "*"
 
 {about}"#,
-    );
+        )
+    };
 
+    let recipe_file = recipe_dir.join("recipe.yaml");
+    let mut file = std::fs::File::create_new(&recipe_file).context(format!(
+        "Failed to create recipe file \"{}\"",
+        recipe_file.display()
+    ))?;
     file.write_all(content.as_bytes()).context(format!(
         "Failed to populate recipe file \"{}\"",
         recipe_file.display(),
@@ -790,6 +834,198 @@ mod tests {
     use super::*;
 
     use crate::config_file::tests::get_patterns_for;
+
+    #[test]
+    fn test_recipe_template_rendering() {
+        let directory = tempfile::tempdir().unwrap();
+        let template = directory.path().join("custom.yaml");
+        let value = "quoted \"value\"\nwith \\ and [[ untouched ]]";
+        std::fs::write(&template, "[[ value | tojson ]]\n${{ target_platform }}\n").unwrap();
+        let rendered = render_recipe_template(&template, minijinja::context! { value }).unwrap();
+        assert_eq!(
+            serde_json::from_str::<String>(rendered.lines().next().unwrap()).unwrap(),
+            value,
+        );
+        assert!(rendered.ends_with("\n${{ target_platform }}\n"));
+        for invalid in ["[[ unknown_variable ]]", "[% if %]"] {
+            std::fs::write(&template, invalid).unwrap();
+            let error = render_recipe_template(&template, minijinja::context! {}).unwrap_err();
+            assert!(error.to_string().contains("custom.yaml"));
+        }
+        std::fs::remove_file(&template).unwrap();
+        assert!(render_recipe_template(&template, minijinja::context! {}).is_err());
+    }
+
+    #[test]
+    fn test_recipe_overrides_render_liquibase() {
+        let config = crate::config_file::parse_config(Path::new("config.toml")).unwrap();
+        let mut package = config
+            .packages
+            .into_iter()
+            .find(|package| package.name == "liquibase")
+            .unwrap();
+        let repository = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "name": "liquibase",
+            "url": "https://api.github.com/repos/liquibase/liquibase"
+        }))
+        .unwrap();
+        let asset = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "node_id": "asset",
+            "name": "liquibase.tar.gz",
+            "url": "https://example.invalid/asset",
+            "browser_download_url": "https://example.invalid/liquibase.tar.gz",
+            "content_type": "application/gzip",
+            "state": "uploaded",
+            "size": 1,
+            "download_count": 0,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }))
+        .unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        generate_build_script(work_dir.path()).unwrap();
+        for (version, license) in [("4.33.0", "Apache-2.0"), ("5.0.4", "FSL-1.1-ALv2")] {
+            for platform in [Platform::Linux64, Platform::Win64] {
+                let recipe_dir = generate_rattler_build_recipe(
+                    work_dir.path(),
+                    &package,
+                    version,
+                    0,
+                    &platform,
+                    &repository,
+                    &asset,
+                )
+                .unwrap();
+                let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
+                assert!(
+                    recipe.contains(
+                        "requirements:\n  build:\n    - 7zip\n  run:\n    - openjdk >=17"
+                    )
+                );
+                assert!(recipe.contains("if: build_platform == target_platform"));
+                assert!(recipe.contains("share/liquibase/internal/**/liquibase-commercial*.jar"));
+                assert!(recipe.contains("share/liquibase/internal/**/liquibase-checks.jar"));
+                assert!(recipe.contains("- liquibase --version"));
+                assert!(recipe.contains(&format!("license: \"{license}\"")));
+                assert!(recipe.contains("license_file: LICENSE.txt"));
+                assert_eq!(
+                    std::fs::read_to_string(recipe_dir.join("build.sh")).unwrap(),
+                    include_str!("../scripts/build_liquibase.sh")
+                );
+            }
+        }
+        package.repository.owner = "other".to_string();
+        package.name = "renamed".to_string();
+        let recipe_dir = generate_rattler_build_recipe(
+            work_dir.path(),
+            &package,
+            "1.0.0",
+            0,
+            &Platform::Linux64,
+            &repository,
+            &asset,
+        )
+        .unwrap();
+        let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
+        assert!(recipe.contains("name: \"renamed\""));
+        assert!(recipe.contains("openjdk"));
+        assert_eq!(
+            std::fs::read_to_string(recipe_dir.join("build.sh")).unwrap(),
+            include_str!("../scripts/build_liquibase.sh")
+        );
+        let custom_template = package.recipe.recipe_template.take();
+        let custom_script = package.recipe.build_script.take();
+        let recipe_dir = generate_rattler_build_recipe(
+            work_dir.path(),
+            &package,
+            "1.0.1",
+            0,
+            &Platform::Linux64,
+            &repository,
+            &asset,
+        )
+        .unwrap();
+        let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
+        assert!(!recipe.contains("openjdk"));
+        assert!(!recipe.contains("liquibase --version"));
+        assert!(!recipe.contains("license_file:"));
+        assert_eq!(
+            std::fs::read_to_string(recipe_dir.join("build.sh")).unwrap(),
+            include_str!("../scripts/build.sh")
+        );
+        package.recipe.build_script = custom_script;
+        let recipe_dir = generate_rattler_build_recipe(
+            work_dir.path(),
+            &package,
+            "1.0.2",
+            0,
+            &Platform::Linux64,
+            &repository,
+            &asset,
+        )
+        .unwrap();
+        let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
+        assert!(!recipe.contains("openjdk"));
+        assert_eq!(
+            std::fs::read_to_string(recipe_dir.join("build.sh")).unwrap(),
+            include_str!("../scripts/build_liquibase.sh")
+        );
+        package.recipe.build_script = None;
+        package.recipe.recipe_template = custom_template;
+        let recipe_dir = generate_rattler_build_recipe(
+            work_dir.path(),
+            &package,
+            "1.0.3",
+            0,
+            &Platform::Linux64,
+            &repository,
+            &asset,
+        )
+        .unwrap();
+        let recipe = std::fs::read_to_string(recipe_dir.join("recipe.yaml")).unwrap();
+        assert!(recipe.contains("openjdk"));
+        assert_eq!(
+            std::fs::read_to_string(recipe_dir.join("build.sh")).unwrap(),
+            include_str!("../scripts/build.sh")
+        );
+    }
+
+    #[test]
+    fn test_liquibase_distribution_matching() {
+        let config = crate::config_file::parse_config(Path::new("config.toml")).unwrap();
+        let package = config
+            .packages
+            .iter()
+            .find(|package| package.name == "liquibase")
+            .unwrap();
+        let platforms = package.platform_pattern().unwrap();
+        assert_eq!(platforms.len(), 5);
+        for version in ["4.33.0", "5.0.4"] {
+            let distribution = format!("liquibase-{version}.tar.gz");
+            let excluded = [
+                format!("liquibase-additional-{version}.zip"),
+                format!("liquibase-core-{version}.jar"),
+                format!("liquibase-windows-x64-installer-{version}.exe"),
+                format!("liquibase-{version}.tar.gz.asc"),
+                format!("liquibase-{version}.tar.gz.sha256"),
+            ];
+            for platform in [
+                Platform::Linux64,
+                Platform::LinuxAarch64,
+                Platform::Osx64,
+                Platform::OsxArm64,
+                Platform::Win64,
+            ] {
+                let patterns = &platforms[&platform];
+                assert_eq!(match_platform_names(patterns, &[&distribution]), Some(0));
+                for asset in &excluded {
+                    assert_eq!(match_platform_names(patterns, &[asset]), None);
+                }
+            }
+        }
+    }
 
     fn zoxide_names() -> Vec<&'static str> {
         vec![

--- a/src/package_generation.rs
+++ b/src/package_generation.rs
@@ -91,7 +91,7 @@ pub enum PackageResult {
         name: String,
     },
 }
-  
+
 impl PackageResult {
     fn display_name(&self) -> String {
         match self {
@@ -104,7 +104,7 @@ impl PackageResult {
             } => display_name(repository, name),
         }
     }
-  
+
     fn repository(&self) -> &str {
         match self {
             PackageResult::GithubFailed { repository, .. }
@@ -803,6 +803,15 @@ tests:
         recipe_file.display(),
     ))?;
 
+    let upstream_assets = serde_json::json!([{
+        "url": asset.browser_download_url.as_str(),
+        "sha256": extract_digest(asset).map(|(_, value)| value),
+    }]);
+    let manifest = std::fs::File::create_new(recipe_dir.join("upstream-assets.json"))
+        .context("Failed to create upstream asset manifest")?;
+    serde_json::to_writer_pretty(manifest, &upstream_assets)
+        .context("Failed to write upstream asset manifest")?;
+
     Ok(recipe_dir)
 }
 
@@ -910,6 +919,21 @@ mod tests {
                 assert!(recipe.contains("- liquibase --version"));
                 assert!(recipe.contains(&format!("license: \"{license}\"")));
                 assert!(recipe.contains("license_file: LICENSE.txt"));
+                assert_eq!(
+                    recipe.contains("generated-launchers:"),
+                    platform == Platform::Win64,
+                );
+                let manifest: serde_json::Value = serde_json::from_str(
+                    &std::fs::read_to_string(recipe_dir.join("upstream-assets.json")).unwrap(),
+                )
+                .unwrap();
+                assert_eq!(
+                    manifest,
+                    serde_json::json!([{
+                        "url": "https://example.invalid/liquibase.tar.gz",
+                        "sha256": null,
+                    }]),
+                );
                 assert_eq!(
                     std::fs::read_to_string(recipe_dir.join("build.sh")).unwrap(),
                     include_str!("../scripts/build_liquibase.sh")


### PR DESCRIPTION
Add Liquibase to `github-releases` using configurable recipe templates and build scripts for package-specific requirements.

The default packaging path suits standalone binaries, but Liquibase's launchers depend on the relative locations of its JARs. It also needs a Java runtime dependency and version-specific licensing. Overrides let packages express these requirements without adding package-specific branches to the Rust generator.

Each package can independently set `recipe-template` and `build-script`, with paths resolved relative to the configuration file. The template replaces the complete recipe and is rendered with MiniJinja using package, release asset, platform, and repository metadata. Custom `[[ ... ]]` and `[% ... %]` delimiters leave rattler-build's `${{ ... }}` expressions intact. The script is copied into each generated recipe as `build.sh`; omitting either setting retains that part's default behavior.

For Liquibase, the script preserves the distribution under `share/liquibase` and exposes its launcher, while the recipe declares Java 17+, licensing, and package tests. Liquibase 4.x excludes bundled Pro components because no redistribution grant was found in their license. Liquibase 5.x uses FSL-1.1-ALv2; upstream license notices are preserved.

Validated with 57 Rust tests, Clippy, and builds for all five targets. Runtime smoke tests passed on Linux for 4.33.0 and 5.0.4.