### PR TITLE
feat: zine SSG & ziex (zx) web framework in Zig & wgsl-analyzer (WebGPU shader LSP)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3256,6 +3256,9 @@ repository = "kreuzwerker/envplate"
 repository = "kreuzwerker/m1-terraform-provider-helper"
 
 [[packages]]
+repository = "kristoff-it/zine"
+
+[[packages]]
 repository = "ktock/buildg"
 
 [[packages]]
@@ -6498,6 +6501,9 @@ repository = "zellij-org/zellij"
 
 [[packages]]
 repository = "zerocore-ai/microsandbox"
+
+[[packages]]
+repository = "ziex-dev/ziex"
 
 [[packages]]
 repository = "zitadel/zitadel"

--- a/config.toml
+++ b/config.toml
@@ -6284,6 +6284,9 @@ repository = "westpoint-io/lazyrsync"
 repository = "wfxr/csview"
 
 [[packages]]
+repository = "wgsl-analyzer/wgsl-analyzer"
+
+[[packages]]
 repository = "whalebrew/whalebrew"
 
 [[packages]]


### PR DESCRIPTION
I tested `ziex` with pixi `run build-one ziex-dev/ziex` and... seems like I don't need to do any extra work for remapping the executables from `zx-linux-x64` to `zx` or something like that. Because they have different names based on the OS.

But let me know if I need to do anything else. Thanks