### PR TITLE
Add fff-mcp CLI

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1622,6 +1622,10 @@ repository = "dyne/slangroom-exec"
 repository = "dyne/zenroom"
 
 [[packages]]
+repository = "dmtrKovalenko/fff"
+release-prefix = "fff-mcp"
+
+[[packages]]
 repository = "earthly/earthly"
 
 [[packages]]


### PR DESCRIPTION
https://github.com/dmtrKovalenko/fff/releases/latest

Files starting with `fff-mcp` are command-line executables that can be run directly.   

So we need to add a prefix：`release-prefix = "fff-mcp"`

```
└──❯ fff-mcp --help
FFF MCP Server - a high performance & accuracy file finder for AI code assistants

Usage: fff-mcp [OPTIONS] [PATH]

Arguments:
  [PATH]  Base directory to index. Defaults to the current working directory

Options:
      --frecency-db <FRECENCY_DB_PATH>
          Path to the frecency database
      --history-db <HISTORY_DB_PATH>
          Path to the query history database
      --log-file <LOG_FILE>
          Path-shape hint for per-session log files. Each fff-mcp startup writes a fresh sibling file `<stem>+<UTC-timestamp>+<pid>.<ext>` Defaults to `$XDG_STATE_HOME/fff/fff_mcp.log` (`~/.local/state/fff/fff_mcp.log`), on Windows to `%LOCALAPPDATA%\fff\fff_mcp.log` (`~\AppData\Local\fff\fff_mcp.log`)
      --log-level <LOG_LEVEL>
          Log level (e.g. trace, debug, info, warn, error)
      --no-update-check
          Disable automatic update checks on startup
      --no-warmup
          Disable eager mmap warmup after the initial scan. Grep results will still work (files are mmap'd lazily on first access), but the first search may be slightly slower. Useful on very large repos where the warmup would consume too many kernel resources
      --no-content-indexing
          Disable the content index built after the initial scan. This makes grep calls slower but consumes less RAM (recommended to not turn off)
      --content-indexing
          Explicitly enable content indexing even when `--no-warmup` is set
      --no-watch
          Disable the background file-system watcher. Files are scanned once at startup but not monitored for changes
      --max-cached-files <MAX_CACHED_FILES>
          Maximum number of files whose content is kept persistently in memory. Files beyond this limit are still searchable via temporary mmaps that are released after each grep. Defaults to 30 000. Also settable via the FFF_MAX_CACHED_FILES environment variable [env: FFF_MAX_CACHED_FILES=]
      --follow-symlinks
          Follow symlinks during scan and watcher walks. Off by default — enabling on cyclic symlink layouts can wedge the watcher
      --enable-home-scan [<ENABLE_HOME_SCAN>]
          Allow indexing the user's home directory. FFF refuses to init in `~` unless this is set. Also settable via FFF_ENABLE_HOME_SCAN=1 [env: FFF_ENABLE_HOME_SCAN=] [default: false] [possible values: true, false]
      --enable-root-scan [<ENABLE_ROOT_SCAN>]
          Allow indexing the filesystem root, off by default for the same reason. Also settable via FFF_ENABLE_ROOT_SCAN=1 [env: FFF_ENABLE_ROOT_SCAN=] [default: false] [possible values: true, false]
      --healthcheck
          Run a health check and print diagnostic information, then exit
      --idle-timeout-secs <IDLE_TIMEOUT_SECS>
          Timeout of inactivity after which fff mcp will be exited. Even if the parent process is alive we don't want to occupy resources on index and file watches if fff is unused [env: FFF_MCP_IDLE_TIMEOUT_SECS=] [default: 3600]
  -h, --help
          Print help
  -V, --version
          Print version
```
